### PR TITLE
Create type files and move expense type to there

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -3,8 +3,9 @@ module Main exposing (..)
 import Date
 import Html exposing (programWithFlags)
 import Material
-import Model exposing (ExpenseItem, ExpenseType(Debit), Model)
+import Model exposing (Model)
 import Msg exposing (Msg, update)
+import Types exposing (ExpenseItem, ExpenseType(Debit))
 import Views.Root exposing (view)
 
 

--- a/src/Model.elm
+++ b/src/Model.elm
@@ -1,27 +1,7 @@
-module Model
-    exposing
-        ( ExpenseItem
-        , ExpenseType(Credit, Debit)
-        , Model
-        )
+module Model exposing (Model)
 
-import Date exposing (Date)
 import Material
-
-
-type ExpenseType
-    = Credit
-    | Debit
-
-
-type alias ExpenseItem =
-    { amount : Float
-    , category : String
-    , date : Date
-    , description : String
-    , expenseType : ExpenseType
-    , source : String
-    }
+import Types exposing (..)
 
 
 type alias Model =

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -1,0 +1,18 @@
+module Types exposing (..)
+
+import Date exposing (Date)
+
+
+type ExpenseType
+    = Credit
+    | Debit
+
+
+type alias ExpenseItem =
+    { amount : Float
+    , category : String
+    , date : Date
+    , description : String
+    , expenseType : ExpenseType
+    , source : String
+    }

--- a/src/Views/Table.elm
+++ b/src/Views/Table.elm
@@ -3,8 +3,8 @@ module Views.Table exposing (view)
 import Date.Extra as DateE
 import Html exposing (Html, text, div, img)
 import Material.Table as Table
-import Model exposing (ExpenseItem)
 import Msg exposing (Msg)
+import Types exposing (ExpenseItem)
 
 
 itemView : ExpenseItem -> Html Msg


### PR DESCRIPTION
I was trying to make the form and I notice that put the expense type inside the model file can create a circular dependency. Suppose that I create a component for the expensive form. This component will need to expose its internal model and action to the main application. But I will need to use expensive type in the component but it is defined in model.